### PR TITLE
hasStartedRef fix

### DIFF
--- a/src/app/(auth)/signin/github/callback/page.tsx
+++ b/src/app/(auth)/signin/github/callback/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 
@@ -18,11 +18,21 @@ function GitHubSigninCallbackContent() {
 
   const [error,   setError]   = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  // React Strict Mode mounts → unmounts → remounts every component in dev.
+  // hasStartedRef (preserved across remount) ensures we only attempt the
+  // one-time code exchange once — preventing a double-POST that would cause
+  // the second request to fail with "invalid or expired authorization code".
+  const hasStartedRef = useRef(false);
 
   useEffect(() => {
-    let cancelled = false;
+    if (hasStartedRef.current) return;
+    hasStartedRef.current = true;
 
-    async function finish() {
+    // consumeCodeVerifier() is called inside this guarded block so it runs
+    // exactly once regardless of Strict Mode double-invocation.
+    const codeVerifier = consumeCodeVerifier();
+
+    (async () => {
       // The backend redirects here with a short-lived one-time code.
       // e.g. /signin/github/callback?code=ONE_TIME_CODE
       const code = searchParams.get('code');
@@ -41,7 +51,6 @@ function GitHubSigninCallbackContent() {
         return;
       }
 
-      const codeVerifier = consumeCodeVerifier();
       if (!codeVerifier) {
         setError('Missing PKCE verifier. Please try signing in again.');
         setLoading(false);
@@ -50,11 +59,9 @@ function GitHubSigninCallbackContent() {
 
       try {
         const user = await exchangeOAuthCode(code, codeVerifier);
-        if (cancelled) return;
         setUser(user);
         router.replace('/dashboard');
       } catch (err) {
-        if (cancelled) return;
         setError(
           err instanceof Error
             ? err.message
@@ -62,10 +69,7 @@ function GitHubSigninCallbackContent() {
         );
         setLoading(false);
       }
-    }
-
-    finish();
-    return () => { cancelled = true; };
+    })();
   }, [searchParams, router, setUser]);
 
   // ── Error state ───────────────────────────────────────────────────────────────

--- a/src/app/(auth)/signin/google/callback/page.tsx
+++ b/src/app/(auth)/signin/google/callback/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
@@ -18,11 +18,21 @@ function GoogleSigninCallbackContent() {
 
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  // React Strict Mode mounts → unmounts → remounts every component in dev.
+  // hasStartedRef (preserved across remount) ensures we only attempt the
+  // one-time code exchange once — preventing a double-POST that would cause
+  // the second request to fail with "invalid or expired authorization code".
+  const hasStartedRef = useRef(false);
 
   useEffect(() => {
-    let cancelled = false;
+    if (hasStartedRef.current) return;
+    hasStartedRef.current = true;
 
-    async function finish() {
+    // consumeCodeVerifier() is called inside this guarded block so it runs
+    // exactly once regardless of Strict Mode double-invocation.
+    const codeVerifier = consumeCodeVerifier();
+
+    (async () => {
       // The backend redirects here with a short-lived one-time code.
       // e.g. /signin/google/callback?code=ONE_TIME_CODE
       const code = searchParams.get("code");
@@ -41,7 +51,6 @@ function GoogleSigninCallbackContent() {
         return;
       }
 
-      const codeVerifier = consumeCodeVerifier();
       if (!codeVerifier) {
         setError("Missing PKCE verifier. Please try signing in again.");
         setLoading(false);
@@ -50,11 +59,9 @@ function GoogleSigninCallbackContent() {
 
       try {
         const user = await exchangeOAuthCode(code, codeVerifier);
-        if (cancelled) return;
         setUser(user);
         router.replace("/dashboard");
       } catch (err) {
-        if (cancelled) return;
         setError(
           err instanceof Error
             ? err.message
@@ -62,12 +69,7 @@ function GoogleSigninCallbackContent() {
         );
         setLoading(false);
       }
-    }
-
-    finish();
-    return () => {
-      cancelled = true;
-    };
+    })();
   }, [searchParams, router, setUser]);
 
   // ── Error state ──────────────────────────────────────────────────────────────

--- a/src/app/(auth)/signup/github/callback/page.tsx
+++ b/src/app/(auth)/signup/github/callback/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
@@ -18,11 +18,21 @@ function GitHubSignupCallbackContent() {
 
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  // React Strict Mode mounts → unmounts → remounts every component in dev.
+  // hasStartedRef (preserved across remount) ensures we only attempt the
+  // one-time code exchange once — preventing a double-POST that would cause
+  // the second request to fail with "invalid or expired authorization code".
+  const hasStartedRef = useRef(false);
 
   useEffect(() => {
-    let cancelled = false;
+    if (hasStartedRef.current) return;
+    hasStartedRef.current = true;
 
-    async function finish() {
+    // consumeCodeVerifier() is called inside this guarded block so it runs
+    // exactly once regardless of Strict Mode double-invocation.
+    const codeVerifier = consumeCodeVerifier();
+
+    (async () => {
       // The backend redirects here with a short-lived one-time code.
       // e.g. /signup/github/callback?code=ONE_TIME_CODE
       const code = searchParams.get("code");
@@ -40,7 +50,6 @@ function GitHubSignupCallbackContent() {
         return;
       }
 
-      const codeVerifier = consumeCodeVerifier();
       if (!codeVerifier) {
         setError("Missing PKCE verifier. Please try signing up again.");
         setLoading(false);
@@ -49,11 +58,9 @@ function GitHubSignupCallbackContent() {
 
       try {
         const user = await exchangeOAuthCode(code, codeVerifier);
-        if (cancelled) return;
         setUser(user);
         router.replace("/dashboard");
       } catch (err) {
-        if (cancelled) return;
         setError(
           err instanceof Error
             ? err.message
@@ -61,12 +68,7 @@ function GitHubSignupCallbackContent() {
         );
         setLoading(false);
       }
-    }
-
-    finish();
-    return () => {
-      cancelled = true;
-    };
+    })();
   }, [searchParams, router, setUser]);
 
   // ── Error state ───────────────────────────────────────────────────────────

--- a/src/app/(auth)/signup/google/callback/page.tsx
+++ b/src/app/(auth)/signup/google/callback/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
@@ -18,11 +18,21 @@ function GoogleSignupCallbackContent() {
 
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  // React Strict Mode mounts → unmounts → remounts every component in dev.
+  // hasStartedRef (preserved across remount) ensures we only attempt the
+  // one-time code exchange once — preventing a double-POST that would cause
+  // the second request to fail with "invalid or expired authorization code".
+  const hasStartedRef = useRef(false);
 
   useEffect(() => {
-    let cancelled = false;
+    if (hasStartedRef.current) return;
+    hasStartedRef.current = true;
 
-    async function finish() {
+    // consumeCodeVerifier() is called inside this guarded block so it runs
+    // exactly once regardless of Strict Mode double-invocation.
+    const codeVerifier = consumeCodeVerifier();
+
+    (async () => {
       // The backend redirects here with a short-lived one-time code.
       // e.g. /signup/google/callback?code=ONE_TIME_CODE
       const code = searchParams.get("code");
@@ -41,7 +51,6 @@ function GoogleSignupCallbackContent() {
         return;
       }
 
-      const codeVerifier = consumeCodeVerifier();
       if (!codeVerifier) {
         setError("Missing PKCE verifier. Please try signing up again.");
         setLoading(false);
@@ -50,11 +59,9 @@ function GoogleSignupCallbackContent() {
 
       try {
         const user = await exchangeOAuthCode(code, codeVerifier);
-        if (cancelled) return;
         setUser(user);
         router.replace("/dashboard");
       } catch (err) {
-        if (cancelled) return;
         setError(
           err instanceof Error
             ? err.message
@@ -62,12 +69,7 @@ function GoogleSignupCallbackContent() {
         );
         setLoading(false);
       }
-    }
-
-    finish();
-    return () => {
-      cancelled = true;
-    };
+    })();
   }, [searchParams, router, setUser]);
 
   // ── Error state ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
hasStartedRef fix which prevents React Strict Mode's double effect invocation was sending the one-time code to the BE twice, consuming it on the first request and failing on the second